### PR TITLE
出力処理のリファクタリング

### DIFF
--- a/05.ls/.gitignore
+++ b/05.ls/.gitignore
@@ -4,3 +4,4 @@ test*
 .bundle
 vendor
 Gemfile*
+.rubocop*

--- a/05.ls/.gitignore
+++ b/05.ls/.gitignore
@@ -1,3 +1,6 @@
 test*
 *txt
 0ls1.rb
+.bundle
+vendor
+Gemfile*

--- a/05.ls/ls1.rb
+++ b/05.ls/ls1.rb
@@ -1,7 +1,9 @@
+# frozen_string_literal: true
+
 class ListSegment
   attr_accessor :dir, :column_num, :row_num, :row_nums
 
-  def initialize(column_num, pattern="*")
+  def initialize(column_num, pattern = '*')
     @column_num = column_num
     @dir = Dir.glob(pattern)
     @row_num = size / @column_num
@@ -12,11 +14,11 @@ class ListSegment
     @dir.size
   end
 
-  def add_row(add=1)
+  def add_row(add = 1)
     @row_num = row_num + add
   end
 
-  def max_str(add_space=2)
+  def max_str(add_space = 2)
     @dir.map(&:length).max + add_space
   end
 
@@ -28,18 +30,19 @@ class ListSegment
     mod.times do |i|
       row_nums[i] = row_nums[i] + 1
     end
+    add_row
   end
 
-  def print_multiline(pt=0)
+  def print_multiline(leap_num = 0)
     row_num.times do |row|
       column_num.times do |column|
-        file = dir[row + pt]
+        file = dir[row + leap_num]
         if column == (column_num - 1)
           print "#{file.to_s.ljust(max_str)}\n"
-          pt = 0
+          leap_num = 0
         else
-          print "#{file.to_s.ljust(max_str)}"
-          pt += row_nums[column]
+          print file.to_s.ljust(max_str).to_s
+          leap_num += row_nums[column]
           if mod != 0 && row == (row_num - 1) && column == (mod - 1)
             print "\n"
             break
@@ -51,22 +54,17 @@ class ListSegment
 
   def print_oneline
     dir.each do |file|
-      print "#{file.to_s.ljust(max_str)}"
+      print file.to_s.ljust(max_str).to_s
     end
     print "\n"
   end
 
   def output
     if size > column_num
-      if mod != 0
-        update_row_nums
-        add_row
-        print_multiline
-      else
-        print_multiline
-      end
+      update_row_nums if mod != 0
+      print_multiline
     else
       print_oneline
-    end    
+    end
   end
 end

--- a/05.ls/ls1.rb
+++ b/05.ls/ls1.rb
@@ -24,6 +24,12 @@ class ListSegment
     size % @column_num
   end
 
+  def update_row_nums
+    mod.times do |i|
+      row_nums[i] = row_nums[i] + 1
+    end
+  end
+
   def print_oneline
     dir.each do |file|
       print "#{file.to_s.ljust(max_str)}"
@@ -34,9 +40,7 @@ class ListSegment
   def output
     if size > column_num
       if mod != 0
-        mod.times do |i|
-          row_nums[i] = row_nums[i] + 1
-        end
+        update_row_nums
         add_row
         pt = 0
         row_num.times do |row|

--- a/05.ls/ls1.rb
+++ b/05.ls/ls1.rb
@@ -30,6 +30,25 @@ class ListSegment
     end
   end
 
+  def print_multiline(pt=0)
+    row_num.times do |row|
+      column_num.times do |column|
+        file = dir[row + pt]
+        if column == (column_num - 1)
+          print "#{file.to_s.ljust(max_str)}\n"
+          pt = 0
+        else
+          print "#{file.to_s.ljust(max_str)}"
+          pt += row_nums[column]
+          if mod != 0 && row == (row_num - 1) && column == (mod - 1)
+            print "\n"
+            break
+          end
+        end
+      end
+    end
+  end
+
   def print_oneline
     dir.each do |file|
       print "#{file.to_s.ljust(max_str)}"
@@ -42,37 +61,9 @@ class ListSegment
       if mod != 0
         update_row_nums
         add_row
-        pt = 0
-        row_num.times do |row|
-          column_num.times do |column|
-            file = dir[row + pt]
-            if column == (column_num - 1)
-              print "#{file.to_s.ljust(max_str)}\n"
-              pt = 0
-            else
-              print "#{file.to_s.ljust(max_str)}"
-              pt += row_nums[column]
-              if row == (row_num - 1) && column == (mod - 1)
-                print "\n"
-                break
-              end
-            end
-          end
-        end
+        print_multiline
       else
-        pt = 0
-        row_num.times do |row|
-          column_num.times do |column|
-            file = dir[row + pt]
-            if column == (column_num - 1)
-              print "#{file.to_s.ljust(max_str)}\n"
-              pt = 0
-            else
-              print "#{file.to_s.ljust(max_str)}"
-              pt += row_nums[column]
-            end
-          end
-        end
+        print_multiline
       end
     else
       print_oneline

--- a/05.ls/ls1.rb
+++ b/05.ls/ls1.rb
@@ -24,6 +24,13 @@ class ListSegment
     size % @column_num
   end
 
+  def print_oneline
+    dir.each do |file|
+      print "#{file.to_s.ljust(max_str)}"
+    end
+    print "\n"
+  end
+
   def output
     if size > column_num
       if mod != 0
@@ -64,10 +71,7 @@ class ListSegment
         end
       end
     else
-      dir.each do |file|
-        print "#{file.to_s.ljust(max_str)}"
-      end
-      print "\n"
+      print_oneline
     end    
   end
 end


### PR DESCRIPTION
refs #1 
### 変更内容
- `output`メソッドが肥大化しているため、複数のメソッドに分割する