### PR TITLE
【lsコマンドを作る3】-rオプションの追加

### DIFF
--- a/05.ls/ls1.rb
+++ b/05.ls/ls1.rb
@@ -19,7 +19,7 @@ end
 class ListSegment
   def initialize(options = {}, column_num = 3)
     @column_num = column_num
-    @files = files_sort(Dir.glob('*', to_fnm(options)), options)
+    @files = sort_files(Dir.glob('*', to_fnm(options)), options)
   end
 
   def output
@@ -33,7 +33,7 @@ class ListSegment
     options[:select_all_files] ? File::FNM_DOTMATCH : NO_FILE_OPTION
   end
 
-  def files_sort(files, options)
+  def sort_files(files, options)
     options[:reverse_sort] ? files.sort.reverse : files.sort
   end
 

--- a/05.ls/ls1.rb
+++ b/05.ls/ls1.rb
@@ -10,6 +10,7 @@ class Option
     @options = {}
     OptionParser.new do |option|
       option.on('-a') { |v| @options[:select_all_files] = v }
+      option.on('-r') { |v| @options[:reverse_sort] = v }
       option.parse!(ARGV)
     end
   end
@@ -18,7 +19,7 @@ end
 class ListSegment
   def initialize(options = {}, column_num = 3)
     @column_num = column_num
-    @files = Dir.glob('*', to_fnm(options)).sort
+    @files = files_sort(Dir.glob('*', to_fnm(options)), options)
   end
 
   def output
@@ -30,6 +31,10 @@ class ListSegment
 
   def to_fnm(options)
     options[:select_all_files] ? File::FNM_DOTMATCH : NO_FILE_OPTION
+  end
+
+  def files_sort(files, options)
+    options[:reverse_sort] ? files.sort.reverse : files.sort
   end
 
   def mod


### PR DESCRIPTION
### カリキュラム
[lsコマンドを作る3](https://bootcamp.fjord.jp/practices/223)

### 実装内容
- -rコマンドが使えるlsコマンドの実装
  - rubyファイル実行時の第一引数に`-r`と記述すると、逆順にソートされた状態で表示されるようにした

### 実行コマンド
`ruby ls1.rb -r`

### 実行結果
<img width="563" alt="image" src="https://user-images.githubusercontent.com/65857152/201246730-c43933a9-86e7-4def-acae-bf3e5cd0a6ec.png">

### Rubocopの実行結果
<img width="550" alt="image" src="https://user-images.githubusercontent.com/65857152/201246828-43a8b99c-3d0b-4d65-98f6-db15e4d6fcdc.png">