### PR TITLE
【lsコマンドを作る4】-lオプションの追加

### DIFF
--- a/05.ls/ls1.rb
+++ b/05.ls/ls1.rb
@@ -22,6 +22,7 @@ class ListSegment
   def initialize(options = {}, column_num = 3)
     @column_num = set_column_num(column_num, options)
     @files = sort_files(Dir.glob('*', to_fnm(options)), options)
+    @stats = to_stats(@files) if options[:long_format]
   end
 
   def output
@@ -37,6 +38,10 @@ class ListSegment
 
   def to_fnm(options)
     options[:select_all_files] ? File::FNM_DOTMATCH : NO_FILE_OPTION
+  end
+
+  def to_stats(files)
+    files.map { |file| File.lstat(file) }
   end
 
   def sort_files(files, options)

--- a/05.ls/ls1.rb
+++ b/05.ls/ls1.rb
@@ -25,9 +25,13 @@ class ListSegment
     @stats = to_stats(@files) if options[:long_format]
   end
 
-  def output
-    row_num = calc_row_num
-    print_files(row_num)
+  def output(options)
+    if options[:long_format]
+      output_files_in_long_format
+    else
+      row_num = calc_row_num
+      output_files(row_num)
+    end
   end
 
   private
@@ -56,11 +60,15 @@ class ListSegment
     (@files.size / @column_num) + mod
   end
 
+  def calc_total_block_size
+    @stats.map(&:blocks).inject(:+)
+  end
+
   def max_str(add_space = 2)
     @files.map(&:length).max + add_space
   end
 
-  def print_files(row_num)
+  def output_files(row_num)
     row_num.times do |row|
       @column_num.times do |column|
         file = @files[column * row_num + row]
@@ -71,8 +79,12 @@ class ListSegment
       print "\n"
     end
   end
+
+  def output_files_in_long_format
+    puts "total #{calc_total_block_size}"
+  end
 end
 
 opt = Option.new
 ls = ListSegment.new(opt.options)
-ls.output
+ls.output(opt.options)

--- a/05.ls/ls1.rb
+++ b/05.ls/ls1.rb
@@ -101,7 +101,7 @@ module LongFormat
 
   module Counter
     def count_total_block_size
-      @stats.map(&:blocks).inject(:+)
+      @stats.map(&:blocks).sum
     end
 
     def count_max_owner_name_str(stats)

--- a/05.ls/ls1.rb
+++ b/05.ls/ls1.rb
@@ -90,11 +90,11 @@ class ListSegment
   end
 
   def to_timestamp(stat)
-    modified_time = stat.mtime.to_datetime
+    modification_time = stat.mtime.to_datetime
     today = DateTime.now
     half_year_ago = today - 180
     # 半年前〜現在時刻までの変更日時のファイルは時刻表示、それ以外は年表示
-    today > modified_time && modified_time >= half_year_ago ? modified_time.strftime('%_m %_d %H:%M') : modified_time.strftime('%_m %_d %_Y')
+    today > modification_time && modification_time >= half_year_ago ? modification_time.strftime('%_m %_d %H:%M') : modification_time.strftime('%_m %_d %_Y')
   end
 
   def to_symlink_style(symlink)

--- a/05.ls/ls1.rb
+++ b/05.ls/ls1.rb
@@ -57,7 +57,8 @@ class ListSegment
 
   def to_permission_str(stat)
     permit_array = (stat.mode.to_s(8).to_i % 1000).to_s.split('')
-    permit_array.map { |octal| to_ls_permission_style(octal) }.join
+    permission_str = permit_array.map { |octal| to_ls_permission_style(octal) }.join
+    stat.sticky? ? to_sticky_bit(permission_str) : permission_str
   end
 
   def to_ls_permission_style(octal)
@@ -72,6 +73,12 @@ class ListSegment
       '7' => 'rwx'
     }
     permission_patterns[octal]
+  end
+
+  def to_sticky_bit(permission_str)
+    array = permission_str.split('')
+    array.pop == 'x' ? array.push('t') : array.push('T')
+    array.join
   end
 
   def to_owner_name(stat)

--- a/05.ls/ls1.rb
+++ b/05.ls/ls1.rb
@@ -20,7 +20,133 @@ class Option
   end
 end
 
+module LongOption
+  module Converter
+    def to_stats(files)
+      files.map { |file| File.lstat(file) }
+    end
+
+    def to_file_type_str(stat)
+      file_types = { 'file' => '-', 'directory' => 'd', 'link' => 'l' }
+      file_types[stat.ftype]
+    end
+
+    def to_permission_str(stat)
+      permit_array = (stat.mode.to_s(8).to_i % 1000).to_s.chars
+      permission_str = permit_array.map { |octal| to_ls_permission_style(octal) }.join
+      if stat.sticky?
+        to_sticky_bit(permission_str)
+      elsif stat.setuid?
+        to_uid_str(permission_str)
+      elsif stat.setgid?
+        to_gid_str(permission_str)
+      else
+        permission_str
+      end
+    end
+
+    def to_ls_permission_style(octal)
+      permission_patterns = {
+        '0' => '---',
+        '1' => '--x',
+        '2' => '-w-',
+        '3' => '-wx',
+        '4' => 'r--',
+        '5' => 'r-x',
+        '6' => 'rw-',
+        '7' => 'rwx'
+      }
+      permission_patterns[octal]
+    end
+
+    def to_sticky_bit(permission_str)
+      array = permission_str.chars
+      array.pop == 'x' ? array.push('t') : array.push('T')
+      array.join
+    end
+
+    def to_uid_str(permission_str)
+      array = permission_str.chars
+      array[2] = array[2] == 'x' ? 's' : 'S'
+      array.join
+    end
+
+    def to_gid_str(permission_str)
+      array = permission_str.chars
+      array[5] = array[5] == 'x' ? 's' : 'S'
+      array.join
+    end
+
+    def to_owner_name(stat)
+      Etc.getpwuid(stat.uid).name
+    end
+
+    def to_group_name(stat)
+      Etc.getgrgid(stat.gid).name
+    end
+
+    def to_timestamp(stat)
+      modification_time = stat.mtime.to_datetime
+      today = DateTime.now
+      half_year_ago = today - 180
+      # 半年前〜現在時刻までの変更日時のファイルは時刻表示、それ以外は年表示
+      today > modification_time && modification_time >= half_year_ago ? modification_time.strftime('%_m %_d %H:%M') : modification_time.strftime('%_m %_d %_Y')
+    end
+
+    def to_symlink_style(symlink)
+      origin = File.readlink(symlink)
+      "#{symlink} -> #{origin}"
+    end
+  end
+
+  module Calculator
+    def calc_total_block_size
+      @stats.map(&:blocks).inject(:+)
+    end
+
+    def count_max_owner_name_str(stats)
+      stats.map { |stat| to_owner_name(stat).length }.max
+    end
+
+    def count_max_group_name_str(stats)
+      stats.map { |stat| to_group_name(stat).length }.max
+    end
+
+    def count_max_nlink_digit(stats)
+      stats.map(&:nlink).max.abs.to_s.size
+    end
+
+    def count_max_bitesize_digit(stats)
+      stats.map(&:size).max.abs.to_s.size
+    end
+  end
+
+  module Output
+    def output_files_in_long_format
+      puts "total #{calc_total_block_size}" # ブロックサイズの合計
+      max_nlink_digit = count_max_nlink_digit(@stats)
+      max_bitesize_digit = count_max_bitesize_digit(@stats)
+      max_owner_name_str = count_max_owner_name_str(@stats)
+      max_group_name_str = count_max_group_name_str(@stats)
+      @stats.each_with_index do |stat, index|
+        print to_file_type_str(stat) # ファイルタイプ
+        print "#{to_permission_str(stat).ljust(9)}  " # パーミッション
+        print "#{stat.nlink.to_s.rjust(max_nlink_digit)} " # ハードリンク数
+        print "#{to_owner_name(stat).ljust(max_owner_name_str)}  " # オーナー名
+        print "#{to_group_name(stat).ljust(max_group_name_str)}  " # グループ名
+        print "#{stat.size.to_s.rjust(max_bitesize_digit)} " # バイトサイズ（最大値の桁数で右詰め）
+        print "#{to_timestamp(stat)} " # タイムスタンプ（最終更新時刻）
+        puts stat.symlink? ? to_symlink_style(@files[index]) : @files[index]  # ファイル名
+      end
+    end
+  end
+end
+
 class ListSegment
+  include LongOption::Converter
+  include LongOption::Calculator
+  include LongOption::Output
+
   def initialize(options = {}, column_num = 3)
     @column_num = set_column_num(column_num, options)
     @files = sort_files(Dir.glob('*', to_fnm(options)), options)
@@ -46,82 +172,6 @@ class ListSegment
     options[:select_all_files] ? File::FNM_DOTMATCH : NO_FILE_OPTION
   end
 
-  def to_stats(files)
-    files.map { |file| File.lstat(file) }
-  end
-
-  def to_file_type_str(stat)
-    file_types = { 'file' => '-', 'directory' => 'd', 'link' => 'l' }
-    file_types[stat.ftype]
-  end
-
-  def to_permission_str(stat)
-    permit_array = (stat.mode.to_s(8).to_i % 1000).to_s.chars
-    permission_str = permit_array.map { |octal| to_ls_permission_style(octal) }.join
-    if stat.sticky?
-      to_sticky_bit(permission_str)
-    elsif stat.setuid?
-      to_uid_str(permission_str)
-    elsif stat.setgid?
-      to_gid_str(permission_str)
-    else
-      permission_str
-    end
-  end
-
-  def to_ls_permission_style(octal)
-    permission_patterns = {
-      '0' => '---',
-      '1' => '--x',
-      '2' => '-w-',
-      '3' => '-wx',
-      '4' => 'r--',
-      '5' => 'r-x',
-      '6' => 'rw-',
-      '7' => 'rwx'
-    }
-    permission_patterns[octal]
-  end
-
-  def to_sticky_bit(permission_str)
-    array = permission_str.chars
-    array.pop == 'x' ? array.push('t') : array.push('T')
-    array.join
-  end
-
-  def to_uid_str(permission_str)
-    array = permission_str.chars
-    array[2] = array[2] == 'x' ? 's' : 'S'
-    array.join
-  end
-
-  def to_gid_str(permission_str)
-    array = permission_str.chars
-    array[5] = array[5] == 'x' ? 's' : 'S'
-    array.join
-  end
-
-  def to_owner_name(stat)
-    Etc.getpwuid(stat.uid).name
-  end
-
-  def to_group_name(stat)
-    Etc.getgrgid(stat.gid).name
-  end
-
-  def to_timestamp(stat)
-    modification_time = stat.mtime.to_datetime
-    today = DateTime.now
-    half_year_ago = today - 180
-    # 半年前〜現在時刻までの変更日時のファイルは時刻表示、それ以外は年表示
-    today > modification_time && modification_time >= half_year_ago ? modification_time.strftime('%_m %_d %H:%M') : modification_time.strftime('%_m %_d %_Y')
-  end
-
-  def to_symlink_style(symlink)
-    origin = File.readlink(symlink)
-    "#{symlink} -> #{origin}"
-  end
-
   def sort_files(files, options)
     options[:reverse_sort] ? files.sort.reverse : files.sort
   end
@@ -134,28 +184,8 @@ class ListSegment
     (@files.size / @column_num) + mod
   end
 
-  def calc_total_block_size
-    @stats.map(&:blocks).inject(:+)
-  end
-
   def count_max_file_name_str(add_space = 2)
     @files.map(&:length).max + add_space
-  end
-
-  def count_max_owner_name_str(stats)
-    stats.map { |stat| to_owner_name(stat).length }.max
-  end
-
-  def count_max_group_name_str(stats)
-    stats.map { |stat| to_group_name(stat).length }.max
-  end
-
-  def count_max_nlink_digit(stats)
-    stats.map(&:nlink).max.abs.to_s.size
-  end
-
-  def count_max_bitesize_digit(stats)
-    stats.map(&:size).max.abs.to_s.size
   end
 
   def output_files(row_num)
@@ -166,32 +196,6 @@ class ListSegment
 
         print file.to_s.ljust(count_max_file_name_str).to_s
       end
-      print "\n"
-    end
-  end
-
-  def output_files_in_long_format
-    puts "total #{calc_total_block_size}" # ブロックサイズの合計
-    max_nlink_digit = count_max_nlink_digit(@stats)
-    max_bitesize_digit = count_max_bitesize_digit(@stats)
-    max_owner_name_str = count_max_owner_name_str(@stats)
-    max_group_name_str = count_max_group_name_str(@stats)
-    @stats.each_with_index do |stat, index|
-      print to_file_type_str(stat) # ファイルタイプ
-      print to_permission_str(stat).ljust(9) # パーミッション
-      print '  '
-      printf("%#{max_nlink_digit}d", stat.nlink) # ハードリンク数
-      print ' '
-      print to_owner_name(stat).ljust(max_owner_name_str) # オーナー名
-      print '  '
-      print to_group_name(stat).ljust(max_group_name_str) # グループ名
-      print '  '
-      printf("%#{max_bitesize_digit}d", stat.size) # バイトサイズ（最大値の桁数で右詰め）
-      print ' '
-      print to_timestamp(stat) # タイムスタンプ（最終更新時刻）
-      print ' '
-      file = @files[index]
-      print stat.symlink? ? to_symlink_style(file) : file  # ファイル名
       print "\n"
     end
   end

--- a/05.ls/ls1.rb
+++ b/05.ls/ls1.rb
@@ -145,7 +145,7 @@ class ListSegment
 
   def initialize(options = {}, column_num = 3)
     @options = options
-    @column_num = column_num(column_num)
+    @column_num = column_num
     @files = sort_files(Dir.glob('*', to_fnm))
     @stats = to_stats(@files) if options[:long_format]
   end
@@ -155,10 +155,6 @@ class ListSegment
   end
 
   private
-
-  def column_num(column_num)
-    @options[:long_format] ? 1 : column_num
-  end
 
   def to_fnm
     @options[:select_all_files] ? File::FNM_DOTMATCH : NO_FILE_OPTION

--- a/05.ls/ls1.rb
+++ b/05.ls/ls1.rb
@@ -83,11 +83,11 @@ class ListSegment
   end
 
   def to_timestamp(stat)
-    modify_time = stat.mtime.to_datetime
+    modified_time = stat.mtime.to_datetime
     today = DateTime.now
     half_year_ago = today - 180
     # 半年前〜現在時刻までの変更日時のファイルは時刻表示、それ以外は年表示
-    today > modify_time && modify_time >= half_year_ago ? modify_time.strftime('%_m %_d %H:%M') : modify_time.strftime('%_m %_d %_Y')
+    today > modified_time && modified_time >= half_year_ago ? modified_time.strftime('%_m %_d %H:%M') : modified_time.strftime('%_m %_d %_Y')
   end
 
   def to_symlink_style(symlink)

--- a/05.ls/ls1.rb
+++ b/05.ls/ls1.rb
@@ -48,6 +48,11 @@ class ListSegment
     files.map { |file| File.lstat(file) }
   end
 
+  def to_file_type_str(stat)
+    file_types = { 'file' => '-', 'directory' => 'd', 'link' => 'l' }
+    file_types[stat.ftype]
+  end
+
   def sort_files(files, options)
     options[:reverse_sort] ? files.sort.reverse : files.sort
   end
@@ -82,6 +87,9 @@ class ListSegment
 
   def output_files_in_long_format
     puts "total #{calc_total_block_size}"
+    @stats.each do |stat|
+      print to_file_type_str(stat)
+    end
   end
 end
 

--- a/05.ls/ls1.rb
+++ b/05.ls/ls1.rb
@@ -53,6 +53,25 @@ class ListSegment
     file_types[stat.ftype]
   end
 
+  def to_permission_str(stat)
+    permit_array = (stat.mode.to_s(8).to_i % 1000).to_s.split('')
+    permit_array.map { |octal| to_ls_permission_style(octal) }.join
+  end
+
+  def to_ls_permission_style(octal)
+    permission_patterns = {
+      '0' => '---',
+      '1' => '--x',
+      '2' => '-w-',
+      '3' => '-wx',
+      '4' => 'r--',
+      '5' => 'r-x',
+      '6' => 'rw-',
+      '7' => 'rwx'
+    }
+    permission_patterns[octal]
+  end
+
   def sort_files(files, options)
     options[:reverse_sort] ? files.sort.reverse : files.sort
   end
@@ -89,6 +108,8 @@ class ListSegment
     puts "total #{calc_total_block_size}"
     @stats.each do |stat|
       print to_file_type_str(stat)
+      print to_permission_str(stat)
+      print "\n"
     end
   end
 end

--- a/05.ls/ls1.rb
+++ b/05.ls/ls1.rb
@@ -3,6 +3,7 @@
 require 'byebug'
 require 'optparse'
 require 'etc'
+require 'date'
 NO_FILE_OPTION = 0
 
 class Option
@@ -81,6 +82,14 @@ class ListSegment
     Etc.getgrgid(stat.gid).name
   end
 
+  def to_timestamp(stat)
+    modify_time = stat.mtime.to_datetime
+    today = DateTime.now
+    half_year_ago = today - 180
+    # 半年前〜現在時刻までの変更日時のファイルは時刻表示、それ以外は年表示
+    today > modify_time && modify_time >= half_year_ago ? modify_time.strftime('%_m %_d %H:%M') : modify_time.strftime('%_m %_d %_Y')
+  end
+
   def sort_files(files, options)
     options[:reverse_sort] ? files.sort.reverse : files.sort
   end
@@ -132,6 +141,7 @@ class ListSegment
       print '  '
       printf("%#{max_digit}d", stat.size) # バイトサイズ（最大値の桁数で右詰め）
       print ' '
+      print to_timestamp(stat) # タイムスタンプ（最終更新時刻）
       print "\n"
     end
   end

--- a/05.ls/ls1.rb
+++ b/05.ls/ls1.rb
@@ -11,6 +11,7 @@ class Option
     @options = {}
     OptionParser.new do |option|
       option.on('-a') { |v| @options[:select_all_files] = v }
+      option.on('-l') { |v| @options[:long_format] = v }
       option.on('-r') { |v| @options[:reverse_sort] = v }
       option.parse!(ARGV)
     end
@@ -19,7 +20,7 @@ end
 
 class ListSegment
   def initialize(options = {}, column_num = 3)
-    @column_num = column_num
+    @column_num = set_column_num(column_num, options)
     @files = sort_files(Dir.glob('*', to_fnm(options)), options)
   end
 
@@ -29,6 +30,10 @@ class ListSegment
   end
 
   private
+
+  def set_column_num(column_num, options)
+    options[:long_format] ? 1 : column_num
+  end
 
   def to_fnm(options)
     options[:select_all_files] ? File::FNM_DOTMATCH : NO_FILE_OPTION

--- a/05.ls/ls1.rb
+++ b/05.ls/ls1.rb
@@ -150,12 +150,7 @@ class ListSegment
   end
 
   def output(options)
-    if options[:long_format]
-      output_files_in_long_format
-    else
-      row_num = calc_row_num
-      output_files(row_num)
-    end
+    options[:long_format] ? output_files_in_long_format : output_files
   end
 
   private
@@ -184,7 +179,8 @@ class ListSegment
     @files.map(&:length).max + add_space
   end
 
-  def output_files(row_num)
+  def output_files
+    row_num = calc_row_num
     row_num.times do |row|
       @column_num.times do |column|
         file = @files[column * row_num + row]

--- a/05.ls/ls1.rb
+++ b/05.ls/ls1.rb
@@ -20,7 +20,7 @@ class Option
   end
 end
 
-module LongOption
+module LongFormat
   module Converter
     def to_stats(files)
       files.map { |file| File.lstat(file) }
@@ -139,9 +139,9 @@ module LongOption
 end
 
 class ListSegment
-  include LongOption::Converter
-  include LongOption::Counter
-  include LongOption::Output
+  include LongFormat::Converter
+  include LongFormat::Counter
+  include LongFormat::Output
 
   def initialize(options = {}, column_num = 3)
     @options = options

--- a/05.ls/ls1.rb
+++ b/05.ls/ls1.rb
@@ -34,12 +34,12 @@ module LongOption
     def to_permission_str(stat)
       permit_array = (stat.mode.to_s(8).to_i % 1000).to_s.chars
       permission_str = permit_array.map { |octal| to_ls_permission_style(octal) }.join
-      if stat.sticky?
-        to_sticky_bit(permission_str)
-      elsif stat.setuid?
+      if stat.setuid?
         to_uid_str(permission_str)
       elsif stat.setgid?
         to_gid_str(permission_str)
+      elsif stat.sticky?
+        to_sticky_bit(permission_str)
       else
         permission_str
       end
@@ -59,12 +59,6 @@ module LongOption
       permission_patterns[octal]
     end
 
-    def to_sticky_bit(permission_str)
-      array = permission_str.chars
-      array.pop == 'x' ? array.push('t') : array.push('T')
-      array.join
-    end
-
     def to_uid_str(permission_str)
       array = permission_str.chars
       array[2] = array[2] == 'x' ? 's' : 'S'
@@ -74,6 +68,12 @@ module LongOption
     def to_gid_str(permission_str)
       array = permission_str.chars
       array[5] = array[5] == 'x' ? 's' : 'S'
+      array.join
+    end
+
+    def to_sticky_bit(permission_str)
+      array = permission_str.chars
+      array[8] = array[8] == 'x' ? 't' : 'T'
       array.join
     end
 

--- a/05.ls/ls1.rb
+++ b/05.ls/ls1.rb
@@ -99,8 +99,8 @@ module LongOption
     end
   end
 
-  module Calculator
-    def calc_total_block_size
+  module Counter
+    def count_total_block_size
       @stats.map(&:blocks).inject(:+)
     end
 
@@ -123,7 +123,7 @@ module LongOption
 
   module Output
     def output_files_in_long_format
-      puts "total #{calc_total_block_size}" # ブロックサイズの合計
+      puts "total #{count_total_block_size}" # ブロックサイズの合計
       @stats.each_with_index do |stat, index|
         print to_file_type_str(stat) # ファイルタイプ
         print "#{to_permission_str(stat).ljust(9)}  " # パーミッション
@@ -140,7 +140,7 @@ end
 
 class ListSegment
   include LongOption::Converter
-  include LongOption::Calculator
+  include LongOption::Counter
   include LongOption::Output
 
   def initialize(options = {}, column_num = 3)

--- a/05.ls/ls1.rb
+++ b/05.ls/ls1.rb
@@ -66,9 +66,7 @@ module LongFormat
 
     def to_permission_str(stat)
       permit_array = (stat.mode.to_s(8).to_i % 1000).to_s.chars
-      owner_permittion_octal = permit_array[0]
-      group_permittion_octal = permit_array[1]
-      other_permittion_octal = permit_array[2]
+      owner_permittion_octal, group_permittion_octal, other_permittion_octal = permit_array
 
       owner = stat.setuid? ? to_uid_permission_style(owner_permittion_octal) : to_permission_style(owner_permittion_octal)
       group = stat.setgid? ? to_uid_permission_style(group_permittion_octal) : to_permission_style(group_permittion_octal)
@@ -138,6 +136,7 @@ module LongFormat
       @stats.each_with_index do |stat, index|
         print to_file_type_str(stat) # ファイルタイプ
         print "#{to_permission_str(stat).ljust(9)}  " # パーミッション
+        print stat.mode.to_s(8)
         print "#{stat.nlink.to_s.rjust(count_max_nlink_digit(@stats))} " # ハードリンク数
         print "#{to_owner_name(stat).ljust(count_max_owner_name_str(@stats))}  " # オーナー名
         print "#{to_group_name(stat).ljust(count_max_group_name_str(@stats))}  " # グループ名

--- a/05.ls/ls1.rb
+++ b/05.ls/ls1.rb
@@ -58,7 +58,15 @@ class ListSegment
   def to_permission_str(stat)
     permit_array = (stat.mode.to_s(8).to_i % 1000).to_s.chars
     permission_str = permit_array.map { |octal| to_ls_permission_style(octal) }.join
-    stat.sticky? ? to_sticky_bit(permission_str) : permission_str
+    if stat.sticky?
+      to_sticky_bit(permission_str)
+    elsif stat.setuid?
+      to_uid_str(permission_str)
+    elsif stat.setgid?
+      to_gid_str(permission_str)
+    else
+      permission_str
+    end
   end
 
   def to_ls_permission_style(octal)
@@ -78,6 +86,18 @@ class ListSegment
   def to_sticky_bit(permission_str)
     array = permission_str.chars
     array.pop == 'x' ? array.push('t') : array.push('T')
+    array.join
+  end
+
+  def to_uid_str(permission_str)
+    array = permission_str.chars
+    array[2] = array[2] == 'x' ? 's' : 'S'
+    array.join
+  end
+
+  def to_gid_str(permission_str)
+    array = permission_str.chars
+    array[5] = array[5] == 'x' ? 's' : 'S'
     array.join
   end
 

--- a/05.ls/ls1.rb
+++ b/05.ls/ls1.rb
@@ -141,7 +141,7 @@ class ListSegment
     max_bitesize_digit = count_max_bitesize_digit(@stats)
     @stats.each_with_index do |stat, index|
       print to_file_type_str(stat) # ファイルタイプ
-      print to_permission_str(stat) # パーミッション
+      print to_permission_str(stat).ljust(9) # パーミッション
       print '  '
       printf("%#{max_nlink_digit}d", stat.nlink) # ハードリンク数
       print ' '

--- a/05.ls/ls1.rb
+++ b/05.ls/ls1.rb
@@ -111,7 +111,7 @@ class ListSegment
     @stats.map(&:blocks).inject(:+)
   end
 
-  def max_str(add_space = 2)
+  def count_max_file_name_str(add_space = 2)
     @files.map(&:length).max + add_space
   end
 
@@ -129,7 +129,7 @@ class ListSegment
         file = @files[column * row_num + row]
         break if file.nil?
 
-        print file.to_s.ljust(max_str).to_s
+        print file.to_s.ljust(count_max_file_name_str).to_s
       end
       print "\n"
     end

--- a/05.ls/ls1.rb
+++ b/05.ls/ls1.rb
@@ -115,7 +115,11 @@ class ListSegment
     @files.map(&:length).max + add_space
   end
 
-  def count_max_digit(stats)
+  def count_max_nlink_digit(stats)
+    stats.map(&:nlink).max.abs.to_s.size
+  end
+
+  def count_max_bitesize_digit(stats)
     stats.map(&:size).max.abs.to_s.size
   end
 
@@ -133,18 +137,19 @@ class ListSegment
 
   def output_files_in_long_format
     puts "total #{calc_total_block_size}" # ブロックサイズの合計
-    max_digit = count_max_digit(@stats)
+    max_nlink_digit = count_max_nlink_digit(@stats)
+    max_bitesize_digit = count_max_bitesize_digit(@stats)
     @stats.each_with_index do |stat, index|
       print to_file_type_str(stat) # ファイルタイプ
       print to_permission_str(stat) # パーミッション
       print '  '
-      print stat.nlink # ハードリンク数
+      printf("%#{max_nlink_digit}d", stat.nlink) # ハードリンク数
       print ' '
       print to_owner_name(stat) # オーナー名
       print '  '
       print to_group_name(stat) # グループ名
       print '  '
-      printf("%#{max_digit}d", stat.size) # バイトサイズ（最大値の桁数で右詰め）
+      printf("%#{max_bitesize_digit}d", stat.size) # バイトサイズ（最大値の桁数で右詰め）
       print ' '
       print to_timestamp(stat) # タイムスタンプ（最終更新時刻）
       print ' '

--- a/05.ls/ls1.rb
+++ b/05.ls/ls1.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'byebug'
 require 'optparse'
 NO_FILE_OPTION = 0
 

--- a/05.ls/ls1.rb
+++ b/05.ls/ls1.rb
@@ -124,17 +124,13 @@ module LongOption
   module Output
     def output_files_in_long_format
       puts "total #{calc_total_block_size}" # ブロックサイズの合計
-      max_nlink_digit = count_max_nlink_digit(@stats)
-      max_bitesize_digit = count_max_bitesize_digit(@stats)
-      max_owner_name_str = count_max_owner_name_str(@stats)
-      max_group_name_str = count_max_group_name_str(@stats)
       @stats.each_with_index do |stat, index|
         print to_file_type_str(stat) # ファイルタイプ
         print "#{to_permission_str(stat).ljust(9)}  " # パーミッション
-        print "#{stat.nlink.to_s.rjust(max_nlink_digit)} " # ハードリンク数
-        print "#{to_owner_name(stat).ljust(max_owner_name_str)}  " # オーナー名
-        print "#{to_group_name(stat).ljust(max_group_name_str)}  " # グループ名
-        print "#{stat.size.to_s.rjust(max_bitesize_digit)} " # バイトサイズ（最大値の桁数で右詰め）
+        print "#{stat.nlink.to_s.rjust(count_max_nlink_digit(@stats))} " # ハードリンク数
+        print "#{to_owner_name(stat).ljust(count_max_owner_name_str(@stats))}  " # オーナー名
+        print "#{to_group_name(stat).ljust(count_max_group_name_str(@stats))}  " # グループ名
+        print "#{stat.size.to_s.rjust(count_max_bitesize_digit(@stats))} " # バイトサイズ（最大値の桁数で右詰め）
         print "#{to_timestamp(stat)} " # タイムスタンプ（最終更新時刻）
         puts stat.symlink? ? to_symlink_style(@files[index]) : @files[index]  # ファイル名
       end

--- a/05.ls/ls1.rb
+++ b/05.ls/ls1.rb
@@ -115,6 +115,10 @@ class ListSegment
     @files.map(&:length).max + add_space
   end
 
+  def count_max_owner_name_str(stats)
+    stats.map { |stat| to_owner_name(stat).length }.max
+  end
+
   def count_max_nlink_digit(stats)
     stats.map(&:nlink).max.abs.to_s.size
   end
@@ -139,13 +143,14 @@ class ListSegment
     puts "total #{calc_total_block_size}" # ブロックサイズの合計
     max_nlink_digit = count_max_nlink_digit(@stats)
     max_bitesize_digit = count_max_bitesize_digit(@stats)
+    max_owner_name_str = count_max_owner_name_str(@stats)
     @stats.each_with_index do |stat, index|
       print to_file_type_str(stat) # ファイルタイプ
       print to_permission_str(stat).ljust(9) # パーミッション
       print '  '
       printf("%#{max_nlink_digit}d", stat.nlink) # ハードリンク数
       print ' '
-      print to_owner_name(stat) # オーナー名
+      print to_owner_name(stat).ljust(max_owner_name_str) # オーナー名
       print '  '
       print to_group_name(stat) # グループ名
       print '  '

--- a/05.ls/ls1.rb
+++ b/05.ls/ls1.rb
@@ -144,27 +144,28 @@ class ListSegment
   include LongOption::Output
 
   def initialize(options = {}, column_num = 3)
-    @column_num = set_column_num(column_num, options)
-    @files = sort_files(Dir.glob('*', to_fnm(options)), options)
+    @options = options
+    @column_num = column_num(column_num)
+    @files = sort_files(Dir.glob('*', to_fnm))
     @stats = to_stats(@files) if options[:long_format]
   end
 
-  def output(options)
-    options[:long_format] ? output_files_in_long_format : output_files
+  def output
+    @options[:long_format] ? output_files_in_long_format : output_files
   end
 
   private
 
-  def set_column_num(column_num, options)
-    options[:long_format] ? 1 : column_num
+  def column_num(column_num)
+    @options[:long_format] ? 1 : column_num
   end
 
-  def to_fnm(options)
-    options[:select_all_files] ? File::FNM_DOTMATCH : NO_FILE_OPTION
+  def to_fnm
+    @options[:select_all_files] ? File::FNM_DOTMATCH : NO_FILE_OPTION
   end
 
-  def sort_files(files, options)
-    options[:reverse_sort] ? files.sort.reverse : files.sort
+  def sort_files(files)
+    @options[:reverse_sort] ? files.sort.reverse : files.sort
   end
 
   def mod
@@ -195,4 +196,4 @@ end
 
 opt = Option.new
 ls = ListSegment.new(opt.options)
-ls.output(opt.options)
+ls.output

--- a/05.ls/ls1.rb
+++ b/05.ls/ls1.rb
@@ -56,7 +56,7 @@ class ListSegment
   end
 
   def to_permission_str(stat)
-    permit_array = (stat.mode.to_s(8).to_i % 1000).to_s.split('')
+    permit_array = (stat.mode.to_s(8).to_i % 1000).to_s.chars
     permission_str = permit_array.map { |octal| to_ls_permission_style(octal) }.join
     stat.sticky? ? to_sticky_bit(permission_str) : permission_str
   end
@@ -76,7 +76,7 @@ class ListSegment
   end
 
   def to_sticky_bit(permission_str)
-    array = permission_str.split('')
+    array = permission_str.chars
     array.pop == 'x' ? array.push('t') : array.push('T')
     array.join
   end

--- a/05.ls/ls1.rb
+++ b/05.ls/ls1.rb
@@ -119,6 +119,10 @@ class ListSegment
     stats.map { |stat| to_owner_name(stat).length }.max
   end
 
+  def count_max_group_name_str(stats)
+    stats.map { |stat| to_group_name(stat).length }.max
+  end
+
   def count_max_nlink_digit(stats)
     stats.map(&:nlink).max.abs.to_s.size
   end
@@ -144,6 +148,7 @@ class ListSegment
     max_nlink_digit = count_max_nlink_digit(@stats)
     max_bitesize_digit = count_max_bitesize_digit(@stats)
     max_owner_name_str = count_max_owner_name_str(@stats)
+    max_group_name_str = count_max_group_name_str(@stats)
     @stats.each_with_index do |stat, index|
       print to_file_type_str(stat) # ファイルタイプ
       print to_permission_str(stat).ljust(9) # パーミッション
@@ -152,7 +157,7 @@ class ListSegment
       print ' '
       print to_owner_name(stat).ljust(max_owner_name_str) # オーナー名
       print '  '
-      print to_group_name(stat) # グループ名
+      print to_group_name(stat).ljust(max_group_name_str) # グループ名
       print '  '
       printf("%#{max_bitesize_digit}d", stat.size) # バイトサイズ（最大値の桁数で右詰め）
       print ' '

--- a/05.ls/ls1.rb
+++ b/05.ls/ls1.rb
@@ -90,6 +90,11 @@ class ListSegment
     today > modify_time && modify_time >= half_year_ago ? modify_time.strftime('%_m %_d %H:%M') : modify_time.strftime('%_m %_d %_Y')
   end
 
+  def to_symlink_style(symlink)
+    origin = File.readlink(symlink)
+    "#{symlink} -> #{origin}"
+  end
+
   def sort_files(files, options)
     options[:reverse_sort] ? files.sort.reverse : files.sort
   end
@@ -129,7 +134,7 @@ class ListSegment
   def output_files_in_long_format
     puts "total #{calc_total_block_size}" # ブロックサイズの合計
     max_digit = count_max_digit(@stats)
-    @stats.each do |stat|
+    @stats.each_with_index do |stat, index|
       print to_file_type_str(stat) # ファイルタイプ
       print to_permission_str(stat) # パーミッション
       print '  '
@@ -142,6 +147,9 @@ class ListSegment
       printf("%#{max_digit}d", stat.size) # バイトサイズ（最大値の桁数で右詰め）
       print ' '
       print to_timestamp(stat) # タイムスタンプ（最終更新時刻）
+      print ' '
+      file = @files[index]
+      print stat.symlink? ? to_symlink_style(file) : file  # ファイル名
       print "\n"
     end
   end


### PR DESCRIPTION
### カリキュラム
[lsコマンドを作る4](https://bootcamp.fjord.jp/practices/224)
### 実装内容
- -lコマンドが使えるlsコマンドの実装
  - ファイルの出力列を1列にする ffa802791b3b50dcd0a6d0d0f60298a1b673f906
  - 各ファイル情報を格納した配列を作成 b5caabc
  - 下記項目の出力
    - ブロックサイズの合計 ac15151
    - ファイルタイプ 3f139da
    - パーミッション 4174c51
      - スティッキービット 9607115
      - SUID(Set User ID) 83770d4
      - SGID(Set Group ID) 83770d4
    - ハードリンクの数 a1e8e6c
    - オーナー名 a1e8e6c
    - グループ名 a1e8e6c
    - バイトサイズ a1e8e6c
    - タイムスタンプ 0a81410
    - ファイル名 734f118
### 実行コマンド
`ruby ls1.rb -l`
### 実行結果
▼`ls -l`と同様の出力になることを確認
![image](https://user-images.githubusercontent.com/65857152/202373378-dc16318a-b557-4a21-adf3-797d19d57b1d.png)
### Rubocopの実行結果
![image](https://user-images.githubusercontent.com/65857152/202372950-a86f2ff3-7874-48f2-9da7-b671db42433c.png)