### PR TITLE
【lsコマンドを作る5】-a -r -lオプションの同時実行

### DIFF
--- a/05.ls/ls1.rb
+++ b/05.ls/ls1.rb
@@ -20,9 +20,42 @@ class Option
 end
 
 module ListSegment
-  class NormalFormat
-    NO_FILE_OPTION = 0
+  NO_FILE_OPTION = 0
 
+  PERMISSION_PATTERNS = {
+    '0' => '---',
+    '1' => '--x',
+    '2' => '-w-',
+    '3' => '-wx',
+    '4' => 'r--',
+    '5' => 'r-x',
+    '6' => 'rw-',
+    '7' => 'rwx'
+  }.freeze
+
+  UID_PERMISSION_PATTERNS = {
+    '0' => '--S',
+    '1' => '--s',
+    '2' => '-wS',
+    '3' => '-ws',
+    '4' => 'r-S',
+    '5' => 'r-s',
+    '6' => 'rwS',
+    '7' => 'rws'
+  }.freeze
+
+  STICKY_PERMISSION_PATTERNS = {
+    '0' => '--T',
+    '1' => '--t',
+    '2' => '-wT',
+    '3' => '-wt',
+    '4' => 'r-T',
+    '5' => 'r-t',
+    '6' => 'rwT',
+    '7' => 'rwt'
+  }.freeze
+
+  class NormalFormat
     def initialize(options = {}, column_num = 3)
       @options = options
       @column_num = column_num
@@ -67,39 +100,6 @@ module ListSegment
   end
 
   class LongFormat < NormalFormat
-    PERMISSION_PATTERNS = {
-      '0' => '---',
-      '1' => '--x',
-      '2' => '-w-',
-      '3' => '-wx',
-      '4' => 'r--',
-      '5' => 'r-x',
-      '6' => 'rw-',
-      '7' => 'rwx'
-    }.freeze
-
-    UID_PERMISSION_PATTERNS = {
-      '0' => '--S',
-      '1' => '--s',
-      '2' => '-wS',
-      '3' => '-ws',
-      '4' => 'r-S',
-      '5' => 'r-s',
-      '6' => 'rwS',
-      '7' => 'rws'
-    }.freeze
-
-    STICKY_PERMISSION_PATTERNS = {
-      '0' => '--T',
-      '1' => '--t',
-      '2' => '-wT',
-      '3' => '-wt',
-      '4' => 'r-T',
-      '5' => 'r-t',
-      '6' => 'rwT',
-      '7' => 'rwt'
-    }.freeze
-
     def initialize(options = {})
       super
       @stats = to_stats(@files)
@@ -115,7 +115,7 @@ module ListSegment
         print "#{to_group_name(stat).ljust(count_max_group_name_str(@stats))}  " # グループ名
         print "#{stat.size.to_s.rjust(count_max_bitesize_digit(@stats))} " # バイトサイズ（最大値の桁数で右詰め）
         print "#{to_timestamp(stat)} " # タイムスタンプ（最終更新時刻）
-        puts stat.symlink? ? to_symlink_style(@files[index]) : @files[index]  # ファイル名
+        puts stat.symlink? ? to_symlink_style(@files[index]) : @files[index] # ファイル名
       end
     end
 

--- a/05.ls/ls1.rb
+++ b/05.ls/ls1.rb
@@ -55,7 +55,7 @@ module ListSegment
     '7' => 'rwt'
   }.freeze
 
-  class NormalFormat
+  class DefaultFormat
     def initialize(options = {}, column_num = 3)
       @options = options
       @column_num = column_num
@@ -99,7 +99,7 @@ module ListSegment
     end
   end
 
-  class LongFormat < NormalFormat
+  class LongFormat < DefaultFormat
     def initialize(options = {})
       super
       @stats = to_stats(@files)
@@ -196,5 +196,5 @@ module ListSegment
 end
 
 opt = Option.new
-ls = opt.options[:long_format] ? ListSegment::LongFormat.new(opt.options) : ListSegment::NormalFormat.new(opt.options)
+ls = opt.options[:long_format] ? ListSegment::LongFormat.new(opt.options) : ListSegment::DefaultFormat.new(opt.options)
 ls.output


### PR DESCRIPTION
### カリキュラム
[lsコマンドを作る5](https://bootcamp.fjord.jp/practices/160)
### 実装内容
- lsコマンドの処理全体をListSegmentモジュールで名前空間化
- longオプション(-l)の処理群をLongFormatクラスに切り出し、NormalFormatクラスを継承させる
### 実行コマンド
`ruby ls1.rb -[オプション]`
### 実行結果
▼`ruby ls1.rb -a`
![image](https://user-images.githubusercontent.com/65857152/203209295-19736892-c8d6-4546-b290-29d6f6dd2424.png)
▼`ruby ls1.rb -l`
![image](https://user-images.githubusercontent.com/65857152/203209461-501ad4e0-51ff-4d88-b5e6-32586de5bb6b.png)
▼`ruby ls1.rb -r`
![image](https://user-images.githubusercontent.com/65857152/203209515-d2c24c43-cead-45e4-a575-fd320c95f9b6.png)
▼`ruby ls1.rb -al`
![image](https://user-images.githubusercontent.com/65857152/203209564-4707daf3-18d1-4fcd-898e-eeeb20b32946.png)
▼`ruby ls1.rb -alr`
![image](https://user-images.githubusercontent.com/65857152/203209180-300f2052-d217-40e4-b543-5fff4646eec6.png)
### Rubocopの実行結果
![image](https://user-images.githubusercontent.com/65857152/203208889-bd4b5dc9-3754-45b5-9ec3-0a13600edf2c.png)